### PR TITLE
Remove platform stat entry

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -137,10 +137,6 @@ const toggleMobileMenu = () => {
                 <div class="stat-number">200+</div>
                 <div class="stat-label">Qonaq</div>
               </div>
-              <div class="stat-item">
-                <div class="stat-number">8</div>
-                <div class="stat-label">Platform</div>
-              </div>
             </div>
             <div class="platforms">
               <h4>Mövcud Platformlar</h4>


### PR DESCRIPTION
## Summary
- remove the platform count stat from the stats grid to eliminate the redundant "8 Platform" item

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc78cdb2ec832d8d013a64961a88a8