### PR TITLE
Remove Google Podcasts from platform list

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -143,7 +143,6 @@ const toggleMobileMenu = () => {
               <div class="platform-list">
                 <span class="platform-tag">Spotify</span>
                 <span class="platform-tag">Apple Podcasts</span>
-                <span class="platform-tag">Google Podcasts</span>
                 <span class="platform-tag">YouTube</span>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove Google Podcasts from the displayed list of available platforms

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc795b1548832d9ce0f6eec908aada