### PR TITLE
Reorder platform tags

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -141,9 +141,9 @@ const toggleMobileMenu = () => {
             <div class="platforms">
               <h4>Mövcud Platformlar</h4>
               <div class="platform-list">
+                <span class="platform-tag">YouTube</span>
                 <span class="platform-tag">Spotify</span>
                 <span class="platform-tag">Apple Podcasts</span>
-                <span class="platform-tag">YouTube</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- reorder the displayed platform tags to list YouTube first, followed by Spotify and Apple Podcasts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc79fe427c832d8be1f405ab6383cc